### PR TITLE
Use multi-stage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,29 @@ MAINTAINER Fred Park <https://github.com/alfpark/docker-ffmpeg>
 
 # build ffmpeg
 RUN apk add --update --no-cache \
-        musl coreutils build-base nasm ca-certificates curl tar \
-        openssl-dev zlib-dev yasm-dev lame-dev freetype-dev opus-dev \
-        rtmpdump-dev x264-dev x265-dev xvidcore-dev libass-dev libwebp-dev \
-        libvorbis-dev libogg-dev libtheora-dev libvpx-dev \
+        build-base \
+        ca-certificates \
+        coreutils \
+        curl \
+        freetype-dev \
+        lame-dev \
+        libass-dev \
+        libogg-dev \
+        libtheora-dev \
+        libvorbis-dev \
+        libvpx-dev \
+        libwebp-dev \
+        musl \
+        nasm \
+        openssl-dev \
+        opus-dev \
+        rtmpdump-dev \
+        tar \
+        x264-dev \
+        x265-dev \
+        xvidcore-dev \
+        yasm-dev \
+        zlib-dev \
     && FFMPEG_VER=3.2.1 \
     && curl -s http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VER}.tar.gz | tar zxvf - -C . \
     && cd ffmpeg-${FFMPEG_VER} \
@@ -26,8 +45,23 @@ FROM alpine:3.4
 
 COPY --from=build /usr/local/bin/ffmpeg /usr/local/bin/
 
-RUN apk add --no-cache \
-        zlib lame freetype faac opus xvidcore libass libwebp libvorbis libogg \
-        libtheora libvpx rtmpdump-dev x264-dev x265-dev ca-certificates
+RUN apk add --update --no-cache \
+        ca-certificates \
+        faac \
+        freetype \
+        lame \
+        libass \
+        libogg \
+        libtheora \
+        libvorbis \
+        libvpx \
+        libwebp \
+        musl \
+        opus \
+        rtmpdump-dev \
+        x264-dev \
+        x265-dev \
+        xvidcore \
+        zlib
 
 ENTRYPOINT ["ffmpeg"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Dockerfile for minimal ffmpeg based on alpine
-FROM gliderlabs/alpine:3.4
+FROM alpine:3.4 as build
+
 MAINTAINER Fred Park <https://github.com/alfpark/docker-ffmpeg>
 
-# install base
+# build ffmpeg
 RUN apk add --update --no-cache \
         musl coreutils build-base nasm ca-certificates curl tar \
         openssl-dev zlib-dev yasm-dev lame-dev freetype-dev opus-dev \
         rtmpdump-dev x264-dev x265-dev xvidcore-dev libass-dev libwebp-dev \
         libvorbis-dev libogg-dev libtheora-dev libvpx-dev \
-    # build and install ffmpeg
     && FFMPEG_VER=3.2.1 \
     && curl -s http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VER}.tar.gz | tar zxvf - -C . \
     && cd ffmpeg-${FFMPEG_VER} \
@@ -19,17 +19,15 @@ RUN apk add --update --no-cache \
         --enable-libx264 --enable-libx265 --enable-libopus --enable-libass \
         --enable-libwebp --enable-librtmp --enable-libtheora \
         --enable-libvorbis --enable-libvpx --enable-libxvid \
-    && make -j"$(nproc)" install \
-    && cd .. \
-    && rm -rf ffmpeg-${FFMPEG_VER} \
-    # cleanup
-    && apk del --purge \
-        coreutils build-base nasm curl tar openssl-dev zlib-dev yasm-dev \
-        lame-dev freetype-dev opus-dev xvidcore-dev libass-dev libwebp-dev \
-        libvorbis-dev libogg-dev libtheora-dev libvpx-dev \
-    && apk add --no-cache \
+    && make -j"$(nproc)" install
+
+# install ffmpeg and runtime dependencies
+FROM alpine:3.4
+
+COPY --from=build /usr/local/bin/ffmpeg /usr/local/bin/
+
+RUN apk add --no-cache \
         zlib lame freetype faac opus xvidcore libass libwebp libvorbis libogg \
-        libtheora libvpx \
-    && rm -rf /var/cache/apk/*
+        libtheora libvpx rtmpdump-dev x264-dev x265-dev ca-certificates
 
 ENTRYPOINT ["ffmpeg"]


### PR DESCRIPTION
Fixes #2

Using the new multi-stage build feature in Docker 17.05, we can
reduce the size of this image by ~50%. Only ffmpeg is copied
and only the necessary dependencies are installed in the
resulting runtime image.

This also has the additional benefit of making it clear what the
runtime dependencies are in the Dockerfile.